### PR TITLE
Flexspin compatibility

### DIFF
--- a/RegresssionTests/RT_utilities.spin2
+++ b/RegresssionTests/RT_utilities.spin2
@@ -289,6 +289,7 @@ pub ShowStats() | blocksUsed, blocksFree, fileCount
 pub showFiles() | ID, Bytes, byte Filename[128], byte Buff[30]
     debug(" ")  ' blank line
     debug("  All Files:")
+    ID := 0
     repeat
         Flash.directory(@ID, @Filename, @Bytes)                     'get next file
         if Filename[0]                                              'is there a filename?

--- a/RegresssionTests/RT_utilities.spin2
+++ b/RegresssionTests/RT_utilities.spin2
@@ -406,6 +406,7 @@ dirEnd          LONG    0              ' ptr = NULL, no more entries
     pCurrRefDir := pDirEntries
     refFileCount := 0
     foundFileCount := 0
+    ID := 0
     repeat
         pRefFilename := LONG[pCurrRefDir][0]            ' get pointer to reference filename -OR- NULL
         refByteCount := LONG[pCurrRefDir][1]            ' get byte count

--- a/flash_fs.spin2
+++ b/flash_fs.spin2
@@ -183,6 +183,11 @@ pub version() : result
 
   return LIB_VERSION
 
+{$flexspin
+var
+   long m_sn_hi, m_sn_lo
+}
+
 pub serial_number() : sn_hi, sn_lo
 
 '' Returns 64-bit unique id of flash chip
@@ -201,7 +206,15 @@ pub serial_number() : sn_hi, sn_lo
 
     flash_command($4B, 1)
     flash_send($00, 4)
+{$flexspin
+#ifdef __FLEXSPIN__
+    flash_receive(@m_sn_hi, 8)
+    sn_hi := m_sn_hi
+    sn_lo := m_sn_lo
+#else
+}
     flash_receive(@sn_hi, 8)
+{$flexspin #endif}
 
     ' UID values are stored Big Endian
     ' -- swap ends to correct LE reads from flash

--- a/flash_fs.spin2
+++ b/flash_fs.spin2
@@ -185,7 +185,7 @@ pub version() : result
 
 {$flexspin
 var
-   long m_sn_hi, m_sn_lo
+   long m_sn_hi, m_sn_lo		' temporary storage for serial number read
 }
 
 pub serial_number() : sn_hi, sn_lo
@@ -208,6 +208,9 @@ pub serial_number() : sn_hi, sn_lo
     flash_send($00, 4)
 {$flexspin
 #ifdef __FLEXSPIN__
+    ' flexspin does not like using HUB variables (@) in inline assembly
+    ' so do the read into a class member in HUB, then copy to the local
+    ' variables in registers
     flash_receive(@m_sn_hi, 8)
     sn_hi := m_sn_hi
     sn_lo := m_sn_lo

--- a/flash_fs.spin2
+++ b/flash_fs.spin2
@@ -2388,12 +2388,19 @@ pri flash_wait()| statusBits
     flash_receive(@statusBits, 1)
   while statusBits.[0]                                                          'loop until BUSY bit clear
 
+{$flexspin
+' flexspin stores local variables in registers, rather than HUB, so for flash commands we need HUB space for temporary storage
+var
+   LONG m_command					' HUB storage for flash_command use
+}
 
 pri flash_command(command, count)
 ' Send flash command to FLASH Chip via SPI
 '
 ' @param command - the command for the chip to execute
-' @param count - number of bytes to send
+' @param count - number of bytes to send: must be between 1 and 4
+'
+' uses the member variable m_command as temporary storage
 
               org
 
@@ -2410,9 +2417,16 @@ pri flash_command(command, count)
               movbyts command,#%%1230                   'reverse order of post-command address bytes for sending
 
               end
-
-  flash_send(@command, count)             'send command
-
+{$flexspin
+#ifdef __FLEXSPIN__
+  ' in flexspin we have to copy the register to HUB explicitly (otherwise @command will force command
+  ' into HUB, which will conflict with using `command` in the inline assembly code)
+  m_command := command                      'copy command from register to HUB memory
+  flash_send(@m_command, count)             'send command
+#else
+}
+  flash_send(@command, count)
+{$flexspin #endif}
 
 pri flash_send(p_buffer, count) | tx_byte
 


### PR DESCRIPTION
Here are the changes to make the fs_flash.spin2 file compatible with FlexSpin. The regression tests also uncovered a FlexSpin bug, which is good, but means that you'll need the latest code from github to run the tests.

The changes are mostly in {$flexspin } comment blocks (so they shouldn't affect PNut performance) except for a few cases where a directory identifier needs to be explicitly initialized to 0 in flexspin; I think having explicit initialization for this kind of thing isn't a bad idea, if only for documentation purposes. But we can easily enclose those in {$flexspin } comments if you prefer.

There are 6 test failures in RT_read_write_block_tests, but I get those with PNut v38 too, so I don't think it's a flexspin bug. Do you get those as well?