### PR TITLE
Fix read count

### DIFF
--- a/RegresssionTests/RT_utilities.spin2
+++ b/RegresssionTests/RT_utilities.spin2
@@ -289,6 +289,7 @@ pub ShowStats() | blocksUsed, blocksFree, fileCount
 pub showFiles() | ID, Bytes, byte Filename[128], byte Buff[30]
     debug(" ")  ' blank line
     debug("  All Files:")
+    ID := 0                                                         'strictly speaking only needed for flexspin, but it helps to remind us that ID must be initialized to 0
     repeat
         flash.directory(@ID, @Filename, @Bytes)                     'get next file
         if Filename[0]                                              'is there a filename?
@@ -405,6 +406,7 @@ dirEnd          LONG    0              ' ptr = NULL, no more entries
     pCurrRefDir := pDirEntries
     refFileCount := 0
     foundFileCount := 0
+    ID := 0                                             ' start seach at beginning
     repeat
         pRefFilename := LONG[pCurrRefDir][0]            ' get pointer to reference filename -OR- NULL
         refByteCount := LONG[pCurrRefDir][1]            ' get byte count

--- a/flash_fs.spin2
+++ b/flash_fs.spin2
@@ -1058,15 +1058,14 @@ pub read(handle, p_buffer, count) : bytes_read | byteIndex, readValue, checkValu
      errorCode := checkValue                                                    ' no, set system error
      bytes_read := 0                                                            ' no, 0 bytes read
   else
+    bytes_read := 0
     repeat byteIndex from 0 to count - 1                                        ' for the max length of the buffer
       if (readValue := rd_byte_no_locks(handle)) < 0                            ' read a byte from the file (or seek location)
           errorCode := readValue                                                ' another error occured, set system error
-          bytes_read := byteIndex                                               ' return bytes read so far
           quit
       else
         BYTE[p_buffer][byteIndex] := readValue                                  ' no error, place byte in the users buffer
-    if errorCode == SUCCESS                                                     ' if no error, return bytes read
-        bytes_read := byteIndex + 1                                             ' return bytes read so far
+        bytes_read++		                                                ' update count of bytes read
 
   'debug("read(", udec_(count),") = (", sdec_(bytes_read),")")
 


### PR DESCRIPTION
The way repeat loop indices are left at the end of loop varies between compilers, even between PNut versions. Here's a change that explicitly counts the bytes as they are read. I think this makes the logic a bit clearer, as a bonus (but YMMV).

I also had to restore a change to RT_utilities to explicitly initialize the directory ID before looping through directory calls; flexspin will usually insert implicit initialization to 0, but for variables that are passed by address to subroutines.