### PR TITLE
Fix write count

### DIFF
--- a/flash_fs.spin2
+++ b/flash_fs.spin2
@@ -878,12 +878,12 @@ pub write(handle, p_buffer, count) : bytes_written | checkValue, byteIndex, wr_v
         wr_value := BYTE[p_buffer][byteIndex]
         if (wr_status := wr_byte_no_locks(handle, wr_value)) < 0                ' write a byte to the file (or to seek location in file)
             errorCode := wr_status                                              ' an error occured, set the error code
-	    if bytes_written == 0                                               ' if no bytes written, return error
-	      bytes_written := errorCode
+            if bytes_written == 0                                               ' if no bytes written, return error
+                bytes_written := errorCode
             quit
         else
-	    bytes_written++                                                     ' keep track of bytes written
-	    
+            bytes_written++                                                     ' keep track of bytes written
+
   lockrel(fsLock)                                                               ' release the lock, we're done with it
 
 

--- a/flash_fs.spin2
+++ b/flash_fs.spin2
@@ -873,15 +873,17 @@ pub write(handle, p_buffer, count) : bytes_written | checkValue, byteIndex, wr_v
      bytes_written := (errorCode := checkValue)                                 ' no, return error code
   else
     'debug("write() [",zstr_(p_buffer),"](",udec_(count),")")
+    bytes_written := 0
     repeat byteIndex from 0 to count - 1                                        ' for the max length of the buffer
         wr_value := BYTE[p_buffer][byteIndex]
         if (wr_status := wr_byte_no_locks(handle, wr_value)) < 0                ' write a byte to the file (or to seek location in file)
-            bytes_written := (errorCode := wr_status)                           ' an error occured, return the error code
+            errorCode := wr_status                                              ' an error occured, set the error code
+	    if bytes_written == 0                                               ' if no bytes written, return error
+	      bytes_written := errorCode
             quit
-
-  if errorCode == SUCCESS                                                       ' if no error reported
-    bytes_written := count                                                      ' return count of bytes written
-
+        else
+	    bytes_written++                                                     ' keep track of bytes written
+	    
   lockrel(fsLock)                                                               ' release the lock, we're done with it
 
 


### PR DESCRIPTION
This changes the write count to reflect the actual number of bytes written. This PR is designed to be applied along with the previous read PR, but the two are independent and could be applied in any order.