### PR TITLE
Added another initialization required by flexspin

### DIFF
--- a/flash_fs.spin2
+++ b/flash_fs.spin2
@@ -1698,6 +1698,8 @@ pri locate_file_byte(head_block_address, file_offset) : block_address, end_ptr |
 ' @local offsetToData - offset to first data byte in block
 ' @local lastDataOffset - offset just past last data byte in block
 ' @local overallOffset - calculated file offset from start of block chain
+
+  overallOffset := 0
   block_address := head_block_address
   if head_block_address <> 0
     repeat                                                                                                'trace blocks to count file bytes


### PR DESCRIPTION
This was causing some seeking to fail, but only sometimes (e.g. the regression tests pass). I'm not sure why flexspin isn't initializating this variable automatically, there's clearly a bug in the initialization detection code, but adding explicit initialization isn't a bad idea in any case.